### PR TITLE
Add 'PayNim.app' to address book

### DIFF
--- a/address-book/address-book.js
+++ b/address-book/address-book.js
@@ -30,6 +30,7 @@ AddressBook.BOOK = {
     'NQ09 VF5Y 1PKV MRM4 5LE1 55KV P6R2 GXYJ XYQF': 'Nimiq Foundation',
     'NQ19 YG54 46TX EHGQ D2R2 V8XA JX84 UFG0 S0MC': 'Nimiq Charity',
     'NQ94 GSXP KNG0 K5YV HFJ1 PYAQ Y5D1 XTQ1 SLFP': 'Nimiq-Faucet.surge.sh',
+    'NQ80 PAYN R93R D0H4 BH8T KPRT SBYE 30A3 PHDL': 'PayNim.app',
 
     // Testnet
     'NQ31 QEPR ED7V 00KC P7UC P1PR DKJC VNU7 E461': 'pool.nimiq-testnet.com',


### PR DESCRIPTION
Hi,

I'd like to add address of my PayNim.app project.
This service allows to send NIM to email address, more info here:
https://www.reddit.com/r/Nimiq/comments/90qhtf/send_and_receive_nim_via_email_address_with/
or https://medium.com/@paynimiq/send-nimiq-cryptocurrency-to-email-address-via-paynim-app-10931a928e5c

https://www.paynim.app/