### PR TITLE
RequestLinkEncoding: add BTC / ETH request link creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "types"
   ],
   "devDependencies": {
+    "big-integer": "^1.6.44",
     "rimraf": "^2.6.3",
     "rollup": "^0.64.0",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.0"
   }
 }

--- a/src/request-link-encoding/RequestLinkEncoding.ts
+++ b/src/request-link-encoding/RequestLinkEncoding.ts
@@ -1,29 +1,56 @@
 import { ValidationUtils } from "../validation-utils/ValidationUtils";
 
-// Note that the encoding scheme is the same as for Safe XRouter aside route parameters (see _makeAside).
+/**
+ * @deprecated
+ */
 export function createRequestLink(
     recipient: string,
     amount?: number, // in NIM
     message?: string,
     basePath: string = window.location.host,
 ) {
+    console.warn('This method is deprecated. Use createNimiqRequestLink instead.');
+    return createNimiqRequestLink(recipient, { amount, message, basePath })
+}
+
+/**
+ * @deprecated
+ */
+export function parseRequestLink(
+    requestLink: string | URL,
+    requiredBasePath?: string,
+) {
+    console.warn('This method is deprecated. Use parseNimiqRequestLink instead.');
+    return parseNimiqRequestLink(requestLink, requiredBasePath);
+}
+
+// Note that the encoding scheme is the same as for Safe XRouter aside route parameters (see _makeAside).
+export function createNimiqRequestLink(
+    recipient: string,
+    options: {
+        amount?: number, // in NIM
+        message?: string,
+        basePath?: string,
+    } = { basePath: window.location.host },
+) {
+    let { amount, message, basePath } = options;
     if (!ValidationUtils.isValidAddress(recipient)) throw new Error(`Not a valid address: ${recipient}`);
     if (amount && typeof amount !== 'number') throw new Error(`Not a valid amount: ${amount}`);
     if (message && typeof message !== 'string') throw new Error(`Not a valid message: ${message}`);
-    const params = [
+    const optionsArray = [
         recipient.replace(/ /g, ''), // strip spaces
         amount || '',
         encodeURIComponent(message || '')
     ];
-    // don't encode empty params (if they are not followed by other non-empty params)
-    while (params[params.length - 1] === '') params.pop();
+    // don't encode empty options (if they are not followed by other non-empty options)
+    while (optionsArray[optionsArray.length - 1] === '') optionsArray.pop();
 
-    if (!basePath.endsWith('/')) basePath = `${basePath}/`;
+    if (!basePath!.endsWith('/')) basePath = `${basePath}/`;
 
-    return `${basePath}#_request/${params.join('/')}_`;
+    return `${basePath}#_request/${optionsArray.join('/')}_`;
 }
 
-export function parseRequestLink(
+export function parseNimiqRequestLink(
     requestLink: string | URL,
     requiredBasePath?: string,
 ) {
@@ -45,11 +72,11 @@ export function parseRequestLink(
     const requestRegexMatch = requestLink.hash.match(requestRegex);
     if (!requestRegexMatch) return null;
 
-    // parse params
-    const paramsSubstr = requestRegexMatch[1];
-    let [recipient, amount, message] = paramsSubstr.split('/');
+    // parse options
+    const optionsSubstr = requestRegexMatch[1];
+    let [recipient, amount, message] = optionsSubstr.split('/');
 
-    // check params
+    // check options
     recipient = recipient
         .replace(/[ +-]|%20/g, '') // strip spaces and dashes
         .replace(/(.)(?=(.{4})+$)/g, '$1 '); // reformat with spaces, forming blocks of 4 chars
@@ -70,4 +97,67 @@ export function parseRequestLink(
         parsedMessage = null;
     }
     return { recipient, amount: parsedAmount, message: parsedMessage };
+}
+
+// following BIP21
+export function createBitcoinRequestLink(
+    recipient: string,
+    options: {
+        amount?: number, // in BTC
+        fee?: number, // suggested fee in BTC, might be ignored
+        label?: string,
+        message?: string,
+    } = {},
+) {
+    if (!recipient) throw new Error('Recipient is required');
+    if (options.amount && (!Number.isFinite(options.amount) || options.amount < 0)) throw new TypeError('Invalid amount');
+    if (options.fee && (!Number.isFinite(options.fee) || options.fee < 0)) throw new TypeError('Invalid fee');
+    const query = new URLSearchParams();
+    const validQueryKeys: ['amount', 'fee', 'label', 'message'] = ['amount', 'fee', 'label', 'message'];
+    validQueryKeys.forEach((key) => {
+        const option = options[key];
+        if (!option) return;
+        // formatted value in BTC without scientific number notation
+        const btcPrecision = 8;
+        const formattedValue = typeof option === 'number'
+            ? option.toFixed(btcPrecision).replace(/\.?0*$/g, '')
+            : option.toString();
+        query.set(key, formattedValue);
+    }, '');
+    const queryString = query.toString() ? `?${query.toString()}` : ''; // also urlEncodes the values
+    return `bitcoin:${recipient}${queryString}`
+}
+
+// subset of EIP681
+export function createEthereumRequestLink(
+    recipient: string, // ETH address or ENS name
+    options: {
+        // Note that ETH values are limited to JS number precision
+        amount?: number, // in ETH
+        gasPrice?: number, // in ETH
+        gasLimit?: number, // integer in gas units, same as parameter 'gas' as specified in EIP681
+        chainId?: number,
+    } = {},
+) {
+    if (!recipient) throw new Error('Recipient is required');
+    const { amount: value, gasPrice, gasLimit, chainId } = options;
+    if (value && (!Number.isFinite(value) || value < 0)) throw new TypeError('Invalid amount');
+    if (gasPrice && (!Number.isFinite(gasPrice) || gasPrice < 0)) throw new TypeError('Invalid gasPrice');
+    if (gasLimit && (!Number.isInteger(gasLimit) || gasLimit < 0)) throw new TypeError('Invalid gasLimit');
+    const eip831Prefix = !recipient.startsWith('0x') ? 'pay-' : '';
+    const chainIdString = chainId !== undefined ? `@${chainId}` : '';
+    const query = new URLSearchParams();
+    const queryOptions: { [key: string]: number | undefined } = { value, gasLimit, gasPrice };
+    Object.keys(queryOptions).forEach((key) => {
+        const option = queryOptions[key];
+        if (!option) return;
+        // formatted ETH values in Wei with manual scientific number notation
+        const ethPrecision = 18;
+        const formattedValue = key === 'amount' || key === 'gasPrice'
+            ? option.toFixed(ethPrecision).replace(/\.?0*$/g, '') + `e${ethPrecision}`
+            : option.toString();
+        query.set(key, formattedValue);
+    }, '');
+    const queryString = query.toString() ? `?${query.toString()}` : ''; // also urlEncodes the values
+    return `ethereum:${eip831Prefix}${recipient}${chainIdString}${queryString}`;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "declaration": true,
     "declarationDir": "./dist/src/",
     "lib": [
-      "es2015",
+      "es2017",
+      "esnext.bigint",
       "es6",
       "dom",
       "dom.iterable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+big-integer@^1.6.44:
+  version "1.6.44"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.44.tgz#4ee9ae5f5839fc11ade338fea216b4513454a539"
+  integrity sha512-7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -94,10 +99,10 @@ rollup@^0.64.0:
     "@types/estree" "0.0.39"
     "@types/node" "*"
 
-typescript@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+typescript@^3.2.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Add support for creating request links following https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki for BTC and https://eips.ethereum.org/EIPS/eip-681 for ETH.
Unfortunately, almost no ETH wallets support or correctly implement handling request links as of now.