### PR TITLE
Fix isValidUtf8

### DIFF
--- a/src/utf8-tools/Utf8Tools.ts
+++ b/src/utf8-tools/Utf8Tools.ts
@@ -51,7 +51,9 @@ export class Utf8Tools {
             return decoder.decode(bytes);
         }
 
-        // Fallback for unsupported TextDecoder
+        // Fallback for unsupported TextDecoder.
+        // Note that this fallback can result in a different decoding for invalid utf8 than the native implementation.
+        // This is the case when a character requires more bytes than are left in the array which is not handled here.
         const out = [];
         let pos = 0;
         let c = 0;
@@ -106,12 +108,11 @@ export class Utf8Tools {
             }
         }
 
-        // Fallback for unsupported TextDecoder. Note that this fallback implementation seems to be partially broken
-        // (see https://github.com/nimiq/nimiq-utils/issues/34). However as TextDecoder support is increasing, it is
-        // not actually that relevant.
+        // Fallback for unsupported TextDecoder
         let i = 0;
 
         while (i < bytes.length) {
+            const bytesLeft = bytes.length - i;
             const first = bytes[i]; // The byte
 
             /* eslint-disable brace-style */
@@ -122,14 +123,14 @@ export class Utf8Tools {
                 else break;
             }
 
-            else if (first >= 0xC2 && first <= 0xDF) { // Possible two-byte
+            else if (first >= 0xC2 && first <= 0xDF && bytesLeft >= 2) { // Possible two-byte
                 const second = bytes[++i];
 
                 if (second >= 0x80 && second <= 0xBF) ++i; // Is valid two-byte
                 else break;
             }
 
-            else if (first === 0xE0) { // Possible three-byte
+            else if (first === 0xE0 && bytesLeft >= 3) { // Possible three-byte
                 const second = bytes[++i];
                 const third = bytes[++i];
 
@@ -138,7 +139,7 @@ export class Utf8Tools {
                 else break;
             }
 
-            else if (first >= 0xE1 && first <= 0xEC) { // Possible three-byte
+            else if (first >= 0xE1 && first <= 0xEC && bytesLeft >= 3) { // Possible three-byte
                 const second = bytes[++i];
                 const third = bytes[++i];
 
@@ -147,7 +148,7 @@ export class Utf8Tools {
                 else break;
             }
 
-            else if (first === 0xED) { // Possible three-byte
+            else if (first === 0xED && bytesLeft >= 3) { // Possible three-byte
                 const second = bytes[++i];
                 const third = bytes[++i];
 
@@ -156,7 +157,7 @@ export class Utf8Tools {
                 else break;
             }
 
-            else if (first >= 0xEE && first <= 0xEF) { // Possible three-byte
+            else if (first >= 0xEE && first <= 0xEF && bytesLeft >= 3) { // Possible three-byte
                 const second = bytes[++i];
                 const third = bytes[++i];
 
@@ -165,7 +166,7 @@ export class Utf8Tools {
                 else break;
             }
 
-            else if (first === 0xF0) { // Possible four-byte
+            else if (first === 0xF0 && bytesLeft >= 4) { // Possible four-byte
                 const second = bytes[++i];
                 const third = bytes[++i];
                 const fourth = bytes[++i];
@@ -176,7 +177,7 @@ export class Utf8Tools {
                 else break;
             }
 
-            else if (first >= 0xF1 && first <= 0xF3) { // Possible four-byte
+            else if (first >= 0xF1 && first <= 0xF3 && bytesLeft >= 4) { // Possible four-byte
                 const second = bytes[++i];
                 const third = bytes[++i];
                 const fourth = bytes[++i];
@@ -187,7 +188,7 @@ export class Utf8Tools {
                 else break;
             }
 
-            else if (first === 0xF4) { // Possible four-byte
+            else if (first === 0xF4 && bytesLeft >= 4) { // Possible four-byte
                 const second = bytes[++i];
                 const third = bytes[++i];
                 const fourth = bytes[++i];

--- a/tests/Utf8Tools.spec.ts
+++ b/tests/Utf8Tools.spec.ts
@@ -1,0 +1,81 @@
+/* global describe, beforeAll, afterAll, it, expect */
+
+import { TextDecoder as NodeTextDecoder } from 'util';
+import { Utf8Tools } from '../src/utf8-tools/Utf8Tools';
+
+declare namespace global {
+    let TextDecoder: any;
+}
+
+const asciiString = 'abc';
+const asciiBytes = new Uint8Array([97, 98, 99]);
+
+// See https://github.com/nimiq/nimiq-utils/issues/34
+const hanziString = '成員國';
+const hanziBytes = new Uint8Array([230, 136, 144, 229, 147, 161, 229, 156, 139]);
+
+// See https://mathiasbynens.be/notes/javascript-unicode#poo-test
+const astralString = '💩';
+const astralBytes = new Uint8Array([240, 159, 146, 169]);
+
+const controlCharString = '\u0000';
+const controlCharBytes = new Uint8Array([0]);
+
+const whiteListedControlCharString = '\n';
+const whiteListedControlCharBytes = new Uint8Array([10]);
+
+function testStringToUtf8ByteArray() {
+    expect(Utf8Tools.stringToUtf8ByteArray(asciiString)).toEqual(asciiBytes);
+    expect(Utf8Tools.stringToUtf8ByteArray(hanziString)).toEqual(hanziBytes);
+    expect(Utf8Tools.stringToUtf8ByteArray(astralString)).toEqual(astralBytes);
+    expect(Utf8Tools.stringToUtf8ByteArray(controlCharString)).toEqual(controlCharBytes);
+    expect(Utf8Tools.stringToUtf8ByteArray(whiteListedControlCharString)).toEqual(whiteListedControlCharBytes);
+}
+
+function testUtf8ByteArrayToString() {
+    expect(Utf8Tools.utf8ByteArrayToString(asciiBytes)).toEqual(asciiString);
+    expect(Utf8Tools.utf8ByteArrayToString(hanziBytes)).toEqual(hanziString);
+    expect(Utf8Tools.utf8ByteArrayToString(astralBytes)).toEqual(astralString);
+    expect(Utf8Tools.utf8ByteArrayToString(controlCharBytes)).toEqual(controlCharString);
+    expect(Utf8Tools.utf8ByteArrayToString(whiteListedControlCharBytes)).toEqual(whiteListedControlCharString);
+}
+
+function testIsValidUtf8() {
+    expect(Utf8Tools.isValidUtf8(asciiBytes)).toBe(true);
+    expect(Utf8Tools.isValidUtf8(hanziBytes)).toBe(true);
+    expect(Utf8Tools.isValidUtf8(astralBytes)).toBe(true);
+    expect(Utf8Tools.isValidUtf8(controlCharBytes)).toBe(true);
+    expect(Utf8Tools.isValidUtf8(whiteListedControlCharBytes)).toBe(true);
+
+    expect(Utf8Tools.isValidUtf8(hanziBytes.subarray(0, hanziBytes.length - 1))).toBe(false);
+    expect(Utf8Tools.isValidUtf8(astralBytes.subarray(0, astralBytes.length - 1))).toBe(false);
+
+    expect(Utf8Tools.isValidUtf8(controlCharBytes, true)).toBe(false);
+    expect(Utf8Tools.isValidUtf8(whiteListedControlCharBytes, true)).toBe(true);
+}
+
+describe('Utf8Tools', () => {
+    describe('native TextDecoder', () => {
+        beforeAll(() => {
+            global.TextDecoder = NodeTextDecoder;
+        });
+
+        afterAll(() => {
+            delete global.TextDecoder;
+        });
+
+        it('can transform strings to utf-8.', testStringToUtf8ByteArray);
+
+        it('can transform utf-8 bytes to strings.', testUtf8ByteArrayToString);
+
+        it('can validate utf-8 bytes.', testIsValidUtf8);
+    });
+
+    describe('fallback', () => {
+        it('can transform strings to utf-8.', testStringToUtf8ByteArray);
+
+        it('can transform utf-8 bytes to strings.', testUtf8ByteArrayToString);
+
+        it('can validate utf-8 bytes.', testIsValidUtf8);
+    });
+});


### PR DESCRIPTION
Resolves #34.
Also now uses native `TextDecoder` if available and reorders tests for single byte case in fallback for faster execution.