### PR TITLE
Add truncateToUtf8ByteLength

### DIFF
--- a/src/utf8-tools/Utf8Tools.ts
+++ b/src/utf8-tools/Utf8Tools.ts
@@ -209,8 +209,13 @@ export class Utf8Tools {
         return i === bytes.length;
     }
 
+    /* eslint-disable lines-between-class-members, no-dupe-class-members */
+    public static truncateToUtf8ByteLength(input: string, length: number, applyEllipsis?: boolean)
+        : { result: string, didTruncate: boolean };
+    public static truncateToUtf8ByteLength(input: Uint8Array, length: number, applyEllipsis?: boolean)
+        : { result: Uint8Array, didTruncate: boolean };
     public static truncateToUtf8ByteLength(input: string | Uint8Array, length: number, applyEllipsis: boolean = true)
-        : { truncatedString: string, truncatedBytes: Uint8Array, didTruncate: boolean } {
+        : { result: string | Uint8Array, didTruncate: boolean } {
         if (length < 0) {
             throw new Error('Invalid byte length');
         }
@@ -224,8 +229,7 @@ export class Utf8Tools {
 
         if (bytes.length <= length) {
             return {
-                truncatedString: typeof input === 'string' ? input : Utf8Tools.utf8ByteArrayToString(input),
-                truncatedBytes: bytes,
+                result: input,
                 didTruncate: false,
             };
         }
@@ -249,9 +253,9 @@ export class Utf8Tools {
         }
 
         return {
-            truncatedString: Utf8Tools.utf8ByteArrayToString(bytes),
-            truncatedBytes: bytes,
+            result: typeof input === 'string' ? Utf8Tools.utf8ByteArrayToString(bytes) : bytes,
             didTruncate: true,
         };
     }
+    /* eslint-enable lines-between-class-members, no-dupe-class-members */
 }

--- a/tests/Utf8Tools.spec.ts
+++ b/tests/Utf8Tools.spec.ts
@@ -82,10 +82,12 @@ describe('Utf8Tools', () => {
     it('can truncate to utf8 byte lengths', () => {
         expect(() => Utf8Tools.truncateToUtf8ByteLength(asciiString, -1)).toThrow();
 
-        const expected = {
+        const expected: {
+            didTruncate: boolean,
+            result: string | Uint8Array,
+        } = {
             didTruncate: false,
-            truncatedString: hanziString,
-            truncatedBytes: hanziBytes,
+            result: hanziString,
         };
         expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length, true)).toEqual(expected);
         expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length, false)).toEqual(expected);
@@ -93,31 +95,31 @@ describe('Utf8Tools', () => {
         expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length + 1, false)).toEqual(expected);
 
         expected.didTruncate = true;
-        expected.truncatedString = asciiString.substring(0, asciiString.length - 1);
-        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expected.result = asciiString.substring(0, asciiString.length - 1);
         expect(Utf8Tools.truncateToUtf8ByteLength(asciiString, asciiBytes.length - 1, false)).toEqual(expected);
-        expect(Utf8Tools.truncateToUtf8ByteLength(asciiBytes, asciiBytes.length - 1, false)).toEqual(expected);
         expect(Utf8Tools.truncateToUtf8ByteLength(asciiString, asciiBytes.length - 1, true)).toEqual(expected);
+        expected.result = Utf8Tools.stringToUtf8ByteArray(expected.result);
+        expect(Utf8Tools.truncateToUtf8ByteLength(asciiBytes, asciiBytes.length - 1, false)).toEqual(expected);
         expect(Utf8Tools.truncateToUtf8ByteLength(asciiBytes, asciiBytes.length - 1, true)).toEqual(expected);
 
-        expected.truncatedString = hanziString.substring(0, hanziString.length - 1);
-        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expected.result = hanziString.substring(0, hanziString.length - 1);
         expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length - 1, false)).toEqual(expected);
+        expected.result = Utf8Tools.stringToUtf8ByteArray(expected.result);
         expect(Utf8Tools.truncateToUtf8ByteLength(hanziBytes, hanziBytes.length - 1, false)).toEqual(expected);
 
-        expected.truncatedString = `${hanziString.substring(0, hanziString.length - 2)}…`;
-        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expected.result = `${hanziString.substring(0, hanziString.length - 2)}…`;
         expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length - 1, true)).toEqual(expected);
+        expected.result = Utf8Tools.stringToUtf8ByteArray(expected.result);
         expect(Utf8Tools.truncateToUtf8ByteLength(hanziBytes, hanziBytes.length - 1, true)).toEqual(expected);
 
-        expected.truncatedString = '';
-        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expected.result = '';
         expect(Utf8Tools.truncateToUtf8ByteLength(astralString, astralBytes.length - 1, false)).toEqual(expected);
+        expected.result = Utf8Tools.stringToUtf8ByteArray(expected.result);
         expect(Utf8Tools.truncateToUtf8ByteLength(astralBytes, astralBytes.length - 1, false)).toEqual(expected);
 
-        expected.truncatedString = '…';
-        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expected.result = '…';
         expect(Utf8Tools.truncateToUtf8ByteLength(astralString, astralBytes.length - 1, true)).toEqual(expected);
+        expected.result = Utf8Tools.stringToUtf8ByteArray(expected.result);
         expect(Utf8Tools.truncateToUtf8ByteLength(astralBytes, astralBytes.length - 1, true)).toEqual(expected);
     });
 });

--- a/tests/Utf8Tools.spec.ts
+++ b/tests/Utf8Tools.spec.ts
@@ -78,4 +78,46 @@ describe('Utf8Tools', () => {
 
         it('can validate utf-8 bytes.', testIsValidUtf8);
     });
+
+    it('can truncate to utf8 byte lengths', () => {
+        expect(() => Utf8Tools.truncateToUtf8ByteLength(asciiString, -1)).toThrow();
+
+        const expected = {
+            didTruncate: false,
+            truncatedString: hanziString,
+            truncatedBytes: hanziBytes,
+        };
+        expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length, true)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length, false)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length + 1, true)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length + 1, false)).toEqual(expected);
+
+        expected.didTruncate = true;
+        expected.truncatedString = asciiString.substring(0, asciiString.length - 1);
+        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expect(Utf8Tools.truncateToUtf8ByteLength(asciiString, asciiBytes.length - 1, false)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(asciiBytes, asciiBytes.length - 1, false)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(asciiString, asciiBytes.length - 1, true)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(asciiBytes, asciiBytes.length - 1, true)).toEqual(expected);
+
+        expected.truncatedString = hanziString.substring(0, hanziString.length - 1);
+        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length - 1, false)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(hanziBytes, hanziBytes.length - 1, false)).toEqual(expected);
+
+        expected.truncatedString = `${hanziString.substring(0, hanziString.length - 2)}…`;
+        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expect(Utf8Tools.truncateToUtf8ByteLength(hanziString, hanziBytes.length - 1, true)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(hanziBytes, hanziBytes.length - 1, true)).toEqual(expected);
+
+        expected.truncatedString = '';
+        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expect(Utf8Tools.truncateToUtf8ByteLength(astralString, astralBytes.length - 1, false)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(astralBytes, astralBytes.length - 1, false)).toEqual(expected);
+
+        expected.truncatedString = '…';
+        expected.truncatedBytes = Utf8Tools.stringToUtf8ByteArray(expected.truncatedString);
+        expect(Utf8Tools.truncateToUtf8ByteLength(astralString, astralBytes.length - 1, true)).toEqual(expected);
+        expect(Utf8Tools.truncateToUtf8ByteLength(astralBytes, astralBytes.length - 1, true)).toEqual(expected);
+    });
 });


### PR DESCRIPTION
Add `truncateToUtf8ByteLength` method to `Utf8Tools` to be used for truncating cookie labels and cashlink messages.
This is an enhanced version of the implementation previously in use in the Hub `CookieJar`.
The new implementation can work on `string` and `Uin8Array` (cookies require `Uint8Array`, cashlinks require `string`), now gives feedback about whether it had to truncate the input, avoids unnecessarily copying the data and can optionally apply an ellipsis.