### PR TITLE
Cast crypto currency symbol to lower case in FiatApi

### DIFF
--- a/src/fiat-api/FiatApi.ts
+++ b/src/fiat-api/FiatApi.ts
@@ -91,6 +91,11 @@ export async function getExchangeRates(
     cryptoCurrencies: Array<FiatApiSupportedCryptoCurrency>,
     vsCurrencies: Array<FiatApiSupportedFiatCurrency | FiatApiSupportedCryptoCurrency>,
 ): Promise<{ [crypto: string]: { [vsCurrency: string]: number | undefined } }> {
+    // Make sure the crypto currencies are lower case so they match the enum (for users that might not be using
+    // typescript which ensures that only valid currency tickers are passed). vsCurrencies do not be to be transformed
+    // because coingecko accepts uppercase and lowercase.
+    cryptoCurrencies = cryptoCurrencies.map((currency) => currency.toLowerCase() as FiatApiSupportedCryptoCurrency);
+
     const coinIds = cryptoCurrencies.map((currency) => COINGECKO_COIN_IDS[currency]);
     const apiResult = await _fetch(`${API_URL}/simple/price`
         + `?ids=${coinIds.join(',')}&vs_currencies=${vsCurrencies.join(',')}`);
@@ -114,7 +119,7 @@ export async function getHistoricExchangeRatesByRange(
     from: number, // in milliseconds
     to: number, // in milliseconds
 ): Promise<Array<[number, number]>> {
-    const coinId = COINGECKO_COIN_IDS[cryptoCurrency];
+    const coinId = COINGECKO_COIN_IDS[cryptoCurrency.toLowerCase() as FiatApiSupportedCryptoCurrency];
     // Note that from and to are expected in seconds but returned timestamps are in ms.
     from = Math.floor(from / 1000);
     to = Math.ceil(to / 1000);


### PR DESCRIPTION
I know that Typescript detects using non-lowercase crypto symbols as type errors, but when used from non-type-checked javascript, this is an error that can frequently be made. So to be nice, we should accept uppercase ticker symbols as well.

For the vs-currency it's not a problem, as coingecko accepts uppercase and lowercase tickers there.