### PR TITLE
Add support for bridged GMD and XOF currencies for current rates

### DIFF
--- a/tests/FiatApi.spec.ts
+++ b/tests/FiatApi.spec.ts
@@ -29,6 +29,15 @@ describe('FiatApi', () => {
         expect(rate[FiatApiSupportedCryptoCurrency.BTC][FiatApiBridgedFiatCurrency.CRC]).toBeGreaterThan(0);
     });
 
+    it('can fetch current bridged GMD and XOF rates for BTC', async () => {
+        const rates = await getExchangeRates(
+            [FiatApiSupportedCryptoCurrency.BTC],
+            [FiatApiBridgedFiatCurrency.GMD, FiatApiBridgedFiatCurrency.XOF],
+        );
+        expect(rates[FiatApiSupportedCryptoCurrency.BTC][FiatApiBridgedFiatCurrency.GMD]).toBeGreaterThan(0);
+        expect(rates[FiatApiSupportedCryptoCurrency.BTC][FiatApiBridgedFiatCurrency.XOF]).toBeGreaterThan(0);
+    });
+
     it('can fetch historic USD rates for BTC', async () => {
         const timestamps = [
             new Date('2023-01-01T00:00:00.000Z').getTime(),

--- a/tests/FiatApi.spec.ts
+++ b/tests/FiatApi.spec.ts
@@ -86,5 +86,5 @@ describe('FiatApi', () => {
         expect(rates.get(timestamps[1])).toBe(9894047.749291496);
         expect(rates.get(timestamps[5])).toBe(14290555.791483302);
         expect(rates.get(timestamps[6])).toBe(14244742.864549162);
-    });
+    }/* , 300000 */); // If this test ist failing, try with a higher timeout
 });


### PR DESCRIPTION
The CPL Firebase API only has current exchange rates to USD, updated once daily. Thus GMD and XOF are only supported for current rates, not for historical rates.