### PR TITLE
Add testnet support for albatross-policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,12 @@
-# Nimiq RPC URL
-# Point this to your Nimiq RPC endpoint
-NIMIQ_RPC_URL=https://example-rpc.nimiq.systems
+# Nimiq RPC URLs
+# Point these to your Nimiq RPC endpoints
+
+# Mainnet settings
+NIMIQ_RPC_URL=
+NIMIQ_RPC_USERNAME=
+NIMIQ_RPC_PASSWORD=
+
+# Testnet settings
+NIMIQ_TESTNET_RPC_URL=
+NIMIQ_TESTNET_RPC_USERNAME=
+NIMIQ_TESTNET_RPC_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Nimiq RPC URL
+# Point this to your Nimiq RPC endpoint
+NIMIQ_RPC_URL=https://example-rpc.nimiq.systems

--- a/.github/workflows/complete-check.yml
+++ b/.github/workflows/complete-check.yml
@@ -2,7 +2,8 @@ name: Complete Check
 
 on:
   - push
-  - pull_request
+  # - pull_request
+  - workflow_dispatch
 
 jobs:
   build:
@@ -16,15 +17,15 @@ jobs:
     - name: Install modules
       run: yarn
     - name: Run
-      # env:
+      env:
       #   COINGECKO_PROXY_AUTHORIZATION_HEADER: ${{ secrets.COINGECKO_PROXY_AUTHORIZATION_HEADER }}
       #   CI_AUTHORIZATION_TOKEN: ${{ secrets.CI_AUTHORIZATION_TOKEN }}
 
       # For Albatross Policy Tests
-      #   NIMIQ_RPC_URL: ${{ secrets.NIMIQ_RPC_URL }}
-      #   NIMIQ_RPC_USERNAME: ${{ secrets.NIMIQ_RPC_USERNAME }}
-      #   NIMIQ_RPC_PASSWORD: ${{ secrets.NIMIQ_RPC_PASSWORD }}
-      #   NIMIQ_TESTNET_RPC_URL: ${{ secrets.NIMIQ_TESTNET_RPC_URL }}
-      #   NIMIQ_TESTNET_RPC_USERNAME: ${{ secrets.NIMIQ_TESTNET_RPC_USERNAME }}
-      #   NIMIQ_TESTNET_RPC_PASSWORD: ${{ secrets.NIMIQ_TESTNET_RPC_PASSWORD }}
+        NIMIQ_RPC_URL: ${{ secrets.NIMIQ_RPC_URL }}
+        NIMIQ_RPC_USERNAME: ${{ secrets.NIMIQ_RPC_USERNAME }}
+        NIMIQ_RPC_PASSWORD: ${{ secrets.NIMIQ_RPC_PASSWORD }}
+        NIMIQ_TESTNET_RPC_URL: ${{ secrets.NIMIQ_TESTNET_RPC_URL }}
+        NIMIQ_TESTNET_RPC_USERNAME: ${{ secrets.NIMIQ_TESTNET_RPC_USERNAME }}
+        NIMIQ_TESTNET_RPC_PASSWORD: ${{ secrets.NIMIQ_TESTNET_RPC_PASSWORD }}
       run: yarn pr

--- a/.github/workflows/complete-check.yml
+++ b/.github/workflows/complete-check.yml
@@ -19,4 +19,12 @@ jobs:
       # env:
       #   COINGECKO_PROXY_AUTHORIZATION_HEADER: ${{ secrets.COINGECKO_PROXY_AUTHORIZATION_HEADER }}
       #   CI_AUTHORIZATION_TOKEN: ${{ secrets.CI_AUTHORIZATION_TOKEN }}
+
+      # For Albatross Policy Tests
+      #   NIMIQ_RPC_URL: ${{ secrets.NIMIQ_RPC_URL }}
+      #   NIMIQ_RPC_USERNAME: ${{ secrets.NIMIQ_RPC_USERNAME }}
+      #   NIMIQ_RPC_PASSWORD: ${{ secrets.NIMIQ_RPC_PASSWORD }}
+      #   NIMIQ_TESTNET_RPC_URL: ${{ secrets.NIMIQ_TESTNET_RPC_URL }}
+      #   NIMIQ_TESTNET_RPC_USERNAME: ${{ secrets.NIMIQ_TESTNET_RPC_USERNAME }}
+      #   NIMIQ_TESTNET_RPC_PASSWORD: ${{ secrets.NIMIQ_TESTNET_RPC_PASSWORD }}
       run: yarn pr

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ delay
 node_modules
 /dist
 /build
+.env

--- a/package.json
+++ b/package.json
@@ -103,10 +103,10 @@
     }
   },
   "dependencies": {
-    "big-integer": "^1.6.44",
-    "dotenv": "^16.5.0"
+    "big-integer": "^1.6.44"
   },
   "devDependencies": {
+    "dotenv": "^16.5.0",
     "@types/jest": "^29.5.11",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.19.1",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     }
   },
   "dependencies": {
-    "big-integer": "^1.6.44"
+    "big-integer": "^1.6.44",
+    "dotenv": "^16.5.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",

--- a/src/albatross-policy/constants.ts
+++ b/src/albatross-policy/constants.ts
@@ -6,8 +6,12 @@ export const TOTAL_SUPPLY = 21e14;
 /**
  * The date of the proof-of-stake migration.
  */
-// export const PROOF_OF_STAKE_MIGRATION_DATE = new Date('2024-11-19T16:45:20.000Z')
-export const PROOF_OF_STAKE_MIGRATION_DATE = new Date('2024-11-19');
+export const PROOF_OF_STAKE_MIGRATION_DATE = new Date('2024-11-19T16:45:20.000Z');
+
+/**
+ * The date of the proof-of-stake migration in **Testnet**.
+ */
+export const PROOF_OF_STAKE_MIGRATION_DATE_TESTNET = new Date('2024-11-13T20:00:00.000Z');
 
 /**
  * The total supply of the cryptocurrency at the proof-of-stake migration date, in NIM.
@@ -29,6 +33,11 @@ export const SUPPLY_AT_PROOF_OF_STAKE_MIGRATION_DATE_TESTNET = 12_030_755_339.52
  * The block height of the proof-of-stake migration.
  */
 export const PROOF_OF_STAKE_MIGRATION_BLOCK = 3456000;
+
+/**
+ * The block height of the proof-of-stake migration in **Testnet**.
+ */
+export const PROOF_OF_STAKE_MIGRATION_BLOCK_TESTNET = 3032010;
 
 /**
  * The initial supply of the cryptocurrency, in Lunas.

--- a/src/albatross-policy/functions.ts
+++ b/src/albatross-policy/functions.ts
@@ -45,24 +45,26 @@ export interface BaseAlbatrossPolicyOptions {
  * Get the PoS migration block height.
  * @param options - Policy options. {@link BaseAlbatrossPolicyOptions}
  */
-export function getMigrationBlock(options: BaseAlbatrossPolicyOptions = { network: 'main-albatross' }) {
-    if (options.migrationBlock !== undefined) return options.migrationBlock;
-    const { isTestnet, isMainnet } = getNetwork(options.network);
+export function getMigrationBlock(options: BaseAlbatrossPolicyOptions = {}) {
+    const { network = 'main-albatross', migrationBlock } = options;
+    if (migrationBlock !== undefined) return migrationBlock;
+    const { isTestnet, isMainnet } = getNetwork(network);
     if (isTestnet) return PROOF_OF_STAKE_MIGRATION_BLOCK_TESTNET;
     if (isMainnet) return PROOF_OF_STAKE_MIGRATION_BLOCK;
-    throw new Error(`Network "${options.network}" not implemented.`);
+    throw new Error(`Network "${network}" not implemented.`);
 }
 
 /**
  * Get migration block info for a network.
  * @param opts - Contains optional network. {@link BaseAlbatrossPolicyOptions}
  */
-export function getMigrationBlockInfo({ network }: Pick<BaseAlbatrossPolicyOptions, 'network'> = {}) {
-    const migrationBlock = getMigrationBlock({ network });
+export function getMigrationBlockInfo(options: BaseAlbatrossPolicyOptions = {}) {
+    const { network } = options;
     const { isTestnet, isMainnet } = getNetwork(network);
     if (!isTestnet && !isMainnet) {
         throw new Error(`Network "${network}" not implemented.`);
     }
+    const migrationBlock = getMigrationBlock(options);
     const date = isTestnet
         ? PROOF_OF_STAKE_MIGRATION_DATE_TESTNET
         : PROOF_OF_STAKE_MIGRATION_DATE;

--- a/tests/AlbatrossPolicy.spec.ts
+++ b/tests/AlbatrossPolicy.spec.ts
@@ -10,8 +10,26 @@ import * as functions from '../src/albatross-policy/functions';
 
 dotenv.config();
 
-async function rpcCall(method: string, params: any[], options: { url: string }): Promise<any> {
-    const headers = { 'Content-Type': 'application/json' };
+interface RpcOptions {
+    url?: string;
+    username?: string;
+    password?: string;
+    network?: string;
+}
+
+async function rpcCall(method: string, params: any[], options: RpcOptions): Promise<any> {
+    if (!options.url) {
+        throw new Error('RPC URL is required');
+    }
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+
+    // Add basic auth if credentials are provided
+    if (options.username && options.password) {
+        const auth = Buffer.from(`${options.username}:${options.password}`).toString('base64');
+        headers.Authorization = `Basic ${auth}`;
+    }
+
     const body = JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 });
     const fetchOptions = { method: 'POST', headers, body };
     const response = await fetch(options.url, fetchOptions);
@@ -22,101 +40,130 @@ async function rpcCall(method: string, params: any[], options: { url: string }):
 }
 
 describe('Albatross Policy RPC Comparisons', () => {
-    const url = process.env.NIMIQ_RPC_URL;
-    if (!url) {
+    // Define networks to test
+    const networks = [
+        {
+            name: 'mainnet',
+            url: process.env.NIMIQ_RPC_URL,
+            username: process.env.NIMIQ_RPC_USERNAME,
+            password: process.env.NIMIQ_RPC_PASSWORD,
+            networkParam: 'main-albatross',
+        },
+        {
+            name: 'testnet',
+            url: process.env.NIMIQ_TESTNET_RPC_URL,
+            username: process.env.NIMIQ_TESTNET_RPC_USERNAME,
+            password: process.env.NIMIQ_TESTNET_RPC_PASSWORD,
+            networkParam: 'test-albatross',
+        },
+    ];
+
+    // Filter out networks with missing URLs
+    const availableNetworks = networks.filter((network) => network.url);
+
+    if (availableNetworks.length === 0) {
         console.warn(
             '**********************************************************\n'
-            + '* ERROR: NIMIQ_RPC_URL environment variable is not set!  *\n'
+            + '* ERROR: No RPC URL environment variables are set!       *\n'
             + '**********************************************************',
         );
 
-        it('skips all tests due to missing NIMIQ_RPC_URL', () => {
-            console.warn('All RPC comparison tests skipped due to missing NIMIQ_RPC_URL');
+        it('skips all tests due to missing RPC URLs', () => {
+            console.warn('All RPC comparison tests skipped due to missing RPC URLs');
         });
 
         return;
     }
 
-    it('verifies RPC connection by testing a small case', async () => {
-        if (!url) return;
-        const result = await rpcCall('getEpochAt', [3_000_000], { url });
-        expect(typeof result).toBe('number');
-    });
+    // Run tests for each available network
+    availableNetworks.forEach((network) => {
+        describe(`Network: ${network.name}`, () => {
+            const { url, username, password, networkParam } = network;
 
-    const { getMigrationBlock } = functions;
+            it('verifies RPC connection by testing a small case', async () => {
+                const result = await rpcCall('getEpochAt', [3_000_000], { url, username, password });
+                expect(typeof result).toBe('number');
+            });
 
-    const testBlocks = [
-        getMigrationBlock() - 1, // Pre-migration block
-        getMigrationBlock(), // Migration block
-        getMigrationBlock() + 1,
-        getMigrationBlock() + BLOCKS_PER_EPOCH * 5 + 100,
-        getMigrationBlock() + BLOCKS_PER_EPOCH * 10_000,
-    ];
+            const { getMigrationBlock } = functions;
 
-    const epochs = [1, 10, 100, 1000];
+            // Get migration block for the current network
+            const migrationBlock = getMigrationBlock({ network: networkParam });
 
-    const rpcBlockMapping = [
-        { fnName: 'epochAt', rpcName: 'getEpochAt' },
-        { fnName: 'epochIndexAt', rpcName: 'getEpochIndexAt' },
-        { fnName: 'batchAt', rpcName: 'getBatchAt' },
-        { fnName: 'batchIndexAt', rpcName: 'getBatchIndexAt' },
-        { fnName: 'isMacroBlockAt', rpcName: 'isMacroBlockAt' },
-        { fnName: 'isElectionBlockAt', rpcName: 'isElectionBlockAt' },
-        { fnName: 'isMicroBlockAt', rpcName: 'isMicroBlockAt' },
-        { fnName: 'macroBlockAfter', rpcName: 'getMacroBlockAfter' },
-        { fnName: 'lastMacroBlock', rpcName: 'getLastMacroBlock' },
-        { fnName: 'electionBlockAfter', rpcName: 'getElectionBlockAfter' },
-        { fnName: 'firstBatchOfEpoch', rpcName: 'getFirstBatchOfEpoch' },
-        { fnName: 'blockAfterReportingWindow', rpcName: 'getBlockAfterReportingWindow' },
-        { fnName: 'blockAfterJail', rpcName: 'getBlockAfterJail' },
-    ] as { fnName: keyof typeof functions, rpcName: string }[];
+            const testBlocks = [
+                migrationBlock - 1, // Pre-migration block
+                migrationBlock, // Migration block
+                migrationBlock + 1,
+                migrationBlock + BLOCKS_PER_EPOCH * 5 + 100,
+                migrationBlock + BLOCKS_PER_EPOCH * 10_000,
+            ];
 
-    const rpcEpochMapping = [
-        { fnName: 'firstBlockOf', rpcName: 'getFirstBlockOf' },
-        { fnName: 'electionBlockOf', rpcName: 'getElectionBlockOf' },
-    ] as { fnName: keyof typeof functions, rpcName: string }[];
+            const epochs = [1, 10, 100, 1000];
 
-    /**
-     * Functions not tested via RPC:
-     * - getMigrationBlock: Internal calculation function
-     * - getMigrationBlockInfo: Returns derived data
-     * - batchDelayPenalty
-     * - lastBlockOfReportingWindow
-     */
+            const rpcBlockMapping = [
+                { fnName: 'epochAt', rpcName: 'getEpochAt' },
+                { fnName: 'epochIndexAt', rpcName: 'getEpochIndexAt' },
+                { fnName: 'batchAt', rpcName: 'getBatchAt' },
+                { fnName: 'batchIndexAt', rpcName: 'getBatchIndexAt' },
+                { fnName: 'isMacroBlockAt', rpcName: 'isMacroBlockAt' },
+                { fnName: 'isElectionBlockAt', rpcName: 'isElectionBlockAt' },
+                { fnName: 'isMicroBlockAt', rpcName: 'isMicroBlockAt' },
+                { fnName: 'macroBlockAfter', rpcName: 'getMacroBlockAfter' },
+                { fnName: 'lastMacroBlock', rpcName: 'getLastMacroBlock' },
+                { fnName: 'electionBlockAfter', rpcName: 'getElectionBlockAfter' },
+                { fnName: 'firstBatchOfEpoch', rpcName: 'getFirstBatchOfEpoch' },
+                { fnName: 'blockAfterReportingWindow', rpcName: 'getBlockAfterReportingWindow' },
+                { fnName: 'blockAfterJail', rpcName: 'getBlockAfterJail' },
+            ] as { fnName: keyof typeof functions, rpcName: string }[];
 
-    // Test block-based functions
-    rpcBlockMapping.forEach(({ fnName, rpcName }) => {
-        const fn = functions[fnName];
-        describe(fnName, () => {
-            testBlocks.forEach((block) => {
-                // Skip problematic test case
-                if (fnName === 'lastMacroBlock' && block === 3455999) {
-                    it.skip(`matches RPC ${rpcName} for block ${block} (skipped - RPC returns error for pre-Albatross blocks)`, async () => {
-                        // Pre-Albatross blocks don't have macro blocks
+            const rpcEpochMapping = [
+                { fnName: 'firstBlockOf', rpcName: 'getFirstBlockOf' },
+                { fnName: 'electionBlockOf', rpcName: 'getElectionBlockOf' },
+            ] as { fnName: keyof typeof functions, rpcName: string }[];
+
+            /**
+             * Functions not tested via RPC:
+             * - getMigrationBlock: Internal calculation function
+             * - getMigrationBlockInfo: Returns derived data
+             * - batchDelayPenalty
+             * - lastBlockOfReportingWindow
+             */
+
+            // Test block-based functions
+            rpcBlockMapping.forEach(({ fnName, rpcName }) => {
+                const fn = functions[fnName];
+                describe(fnName, () => {
+                    testBlocks.forEach((block) => {
+                        // Skip problematic test case
+                        if (fnName === 'lastMacroBlock' && block === migrationBlock - 1) {
+                            it.skip(`matches RPC ${rpcName} for block ${block} (skipped - RPC returns error for pre-Albatross blocks)`, async () => {
+                                // Pre-Albatross blocks don't have macro blocks
+                            });
+                            return;
+                        }
+
+                        it(`matches RPC ${rpcName} for block ${block}`, async () => {
+                            const rpcParams = [block];
+                            const expected = await rpcCall(rpcName, rpcParams, { url, username, password });
+                            const actual = fn(block, { network: networkParam });
+                            expect(actual).toEqual(expected);
+                        });
                     });
-                    return;
-                }
-
-                it(`matches RPC ${rpcName} for block ${block}`, async () => {
-                    const rpcParams = [block];
-                    const expected = await rpcCall(rpcName, rpcParams, { url });
-                    const actual = fn(block);
-                    expect(actual).toEqual(expected);
                 });
             });
-        });
-    });
 
-    // Test epoch-based functions
-    rpcEpochMapping.forEach(({ fnName, rpcName }) => {
-        const fn = functions[fnName];
-        describe(fnName, () => {
-            epochs.forEach((epoch) => {
-                it(`matches RPC ${rpcName} for epoch ${epoch}`, async () => {
-                    const rpcParams = [epoch];
-                    const expected = await rpcCall(rpcName, rpcParams, { url });
-                    const actual = fn(epoch);
-                    expect(actual).toEqual(expected);
+            // Test epoch-based functions
+            rpcEpochMapping.forEach(({ fnName, rpcName }) => {
+                const fn = functions[fnName];
+                describe(fnName, () => {
+                    epochs.forEach((epoch) => {
+                        it(`matches RPC ${rpcName} for epoch ${epoch}`, async () => {
+                            const rpcParams = [epoch];
+                            const expected = await rpcCall(rpcName, rpcParams, { url, username, password });
+                            const actual = fn(epoch, { network: networkParam });
+                            expect(actual).toEqual(expected);
+                        });
+                    });
                 });
             });
         });

--- a/tests/AlbatrossPolicy.spec.ts
+++ b/tests/AlbatrossPolicy.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ *
+ * This test validates our client-side calculations match the RPC implementation.
+ */
+
+import * as dotenv from 'dotenv';
+import { BLOCKS_PER_EPOCH } from '../src/albatross-policy/constants';
+import * as functions from '../src/albatross-policy/functions';
+
+dotenv.config();
+
+async function rpcCall(method: string, params: any[], options: { url: string }): Promise<any> {
+    const headers = { 'Content-Type': 'application/json' };
+    const body = JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 });
+    const fetchOptions = { method: 'POST', headers, body };
+    const response = await fetch(options.url, fetchOptions);
+    if (!response.ok) throw new Error(`HTTP error: ${JSON.stringify({ response, text: await response.text() })}.`);
+    const responseBody = await response.json();
+    if (responseBody.error) throw new Error(`RPC error: ${responseBody.error.message}`);
+    return responseBody.result.data;
+}
+
+describe('Albatross Policy RPC Comparisons', () => {
+    const url = process.env.NIMIQ_RPC_URL;
+    if (!url) {
+        console.warn(
+            '**********************************************************\n'
+            + '* ERROR: NIMIQ_RPC_URL environment variable is not set!  *\n'
+            + '**********************************************************',
+        );
+
+        it('skips all tests due to missing NIMIQ_RPC_URL', () => {
+            console.warn('All RPC comparison tests skipped due to missing NIMIQ_RPC_URL');
+        });
+
+        return;
+    }
+
+    it('verifies RPC connection by testing a small case', async () => {
+        if (!url) return;
+        const result = await rpcCall('getEpochAt', [3_000_000], { url });
+        expect(typeof result).toBe('number');
+    });
+
+    const { getMigrationBlock } = functions;
+
+    const testBlocks = [
+        getMigrationBlock() - 1, // Pre-migration block
+        getMigrationBlock(), // Migration block
+        getMigrationBlock() + 1,
+        getMigrationBlock() + BLOCKS_PER_EPOCH * 5 + 100,
+        getMigrationBlock() + BLOCKS_PER_EPOCH * 10_000,
+    ];
+
+    const epochs = [1, 10, 100, 1000];
+
+    const rpcBlockMapping = [
+        { fnName: 'epochAt', rpcName: 'getEpochAt' },
+        { fnName: 'epochIndexAt', rpcName: 'getEpochIndexAt' },
+        { fnName: 'batchAt', rpcName: 'getBatchAt' },
+        { fnName: 'batchIndexAt', rpcName: 'getBatchIndexAt' },
+        { fnName: 'isMacroBlockAt', rpcName: 'isMacroBlockAt' },
+        { fnName: 'isElectionBlockAt', rpcName: 'isElectionBlockAt' },
+        { fnName: 'isMicroBlockAt', rpcName: 'isMicroBlockAt' },
+        { fnName: 'macroBlockAfter', rpcName: 'getMacroBlockAfter' },
+        { fnName: 'lastMacroBlock', rpcName: 'getLastMacroBlock' },
+        { fnName: 'electionBlockAfter', rpcName: 'getElectionBlockAfter' },
+        { fnName: 'firstBatchOfEpoch', rpcName: 'getFirstBatchOfEpoch' },
+        { fnName: 'blockAfterReportingWindow', rpcName: 'getBlockAfterReportingWindow' },
+        { fnName: 'blockAfterJail', rpcName: 'getBlockAfterJail' },
+    ] as { fnName: keyof typeof functions, rpcName: string }[];
+
+    const rpcEpochMapping = [
+        { fnName: 'firstBlockOf', rpcName: 'getFirstBlockOf' },
+        { fnName: 'electionBlockOf', rpcName: 'getElectionBlockOf' },
+    ] as { fnName: keyof typeof functions, rpcName: string }[];
+
+    /**
+     * Functions not tested via RPC:
+     * - getMigrationBlock: Internal calculation function
+     * - getMigrationBlockInfo: Returns derived data
+     * - batchDelayPenalty
+     * - lastBlockOfReportingWindow
+     */
+
+    // Test block-based functions
+    rpcBlockMapping.forEach(({ fnName, rpcName }) => {
+        const fn = functions[fnName];
+        describe(fnName, () => {
+            testBlocks.forEach((block) => {
+                // Skip problematic test case
+                if (fnName === 'lastMacroBlock' && block === 3455999) {
+                    it.skip(`matches RPC ${rpcName} for block ${block} (skipped - RPC returns error for pre-Albatross blocks)`, async () => {
+                        // Pre-Albatross blocks don't have macro blocks
+                    });
+                    return;
+                }
+
+                it(`matches RPC ${rpcName} for block ${block}`, async () => {
+                    const rpcParams = [block];
+                    const expected = await rpcCall(rpcName, rpcParams, { url });
+                    const actual = fn(block);
+                    expect(actual).toEqual(expected);
+                });
+            });
+        });
+    });
+
+    // Test epoch-based functions
+    rpcEpochMapping.forEach(({ fnName, rpcName }) => {
+        const fn = functions[fnName];
+        describe(fnName, () => {
+            epochs.forEach((epoch) => {
+                it(`matches RPC ${rpcName} for epoch ${epoch}`, async () => {
+                    const rpcParams = [epoch];
+                    const expected = await rpcCall(rpcName, rpcParams, { url });
+                    const actual = fn(epoch);
+                    expect(actual).toEqual(expected);
+                });
+            });
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2077,6 +2077,11 @@ domutils@^3.0.1:
     domelementtype "^2.3.0"
     domhandler "^5.0.3"
 
+dotenv@^16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.5.0.tgz#092b49f25f808f020050051d1ff258e404c78692"
+  integrity sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==
+
 electron-to-chromium@^1.4.601:
   version "1.4.645"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.645.tgz#117f964252eb2f0ff00fc7360cb3080e2cf66e3c"


### PR DESCRIPTION
## 🚀 Summary

- **Add Testnet support** to all PoS‐migration & epoch/batch calculations  
- **New RPC‐comparison tests** for mainnet & testnet

## 🤔 Future work

- https://github.com/nimiq/nimiq-utils/pull/83#issuecomment-2849990084

## 🛠️ Changes

- **constants.ts**  
  - Added `*_TESTNET` variants for migration block & date  
  
- **functions.ts**  
  - Updated `getNetwork` + migration helpers to detect Testnet 
  - New JSDocs
  
- **tests/albatross-policy.spec.ts**  
  - New Jest suite comparing client functions ↔ RPC for both networks
