### PR TITLE
SSR Compatibility: Ensure code works server-side

### DIFF
--- a/src/browser-detection/BrowserDetection.ts
+++ b/src/browser-detection/BrowserDetection.ts
@@ -7,6 +7,10 @@ class BrowserDetection {
         };
     }
 
+    private static isBrowser(): boolean {
+        return typeof globalThis.window !== 'undefined' && typeof globalThis.document !== 'undefined';
+    }
+
     /* eslint-disable max-len */
     // Also includes tablets.
     // Inspired by:
@@ -15,6 +19,7 @@ class BrowserDetection {
     // - http://detectmobilebrowsers.com/about (tablets)
     /* eslint-enable max-len */
     static isMobile() {
+        if (!this.isBrowser()) return false;
         return /i?Phone|iP(ad|od)|Android|BlackBerry|Opera Mini|WPDesktop|Mobi(le)?|Silk/i.test(navigator.userAgent);
     }
 
@@ -37,6 +42,7 @@ class BrowserDetection {
     // - Brave: is indistinguishable from Chrome user agents
     /* eslint-enable max-len */
     static detectBrowser() {
+        if (!this.isBrowser()) return BrowserDetection.Browser.UNKNOWN;
         if (BrowserDetection._detectedBrowser) {
             return BrowserDetection._detectedBrowser;
         }
@@ -69,6 +75,7 @@ class BrowserDetection {
     }
 
     static detectVersion() {
+        if (!this.isBrowser()) return null;
         if (typeof BrowserDetection._detectedVersion !== 'undefined') {
             return BrowserDetection._detectedVersion;
         }
@@ -111,34 +118,42 @@ class BrowserDetection {
     }
 
     static isChrome() {
+        if (!this.isBrowser()) return false;
         return BrowserDetection.detectBrowser() === BrowserDetection.Browser.CHROME;
     }
 
     static isFirefox() {
+        if (!this.isBrowser()) return false;
         return BrowserDetection.detectBrowser() === BrowserDetection.Browser.FIREFOX;
     }
 
     static isOpera() {
+        if (!this.isBrowser()) return false;
         return BrowserDetection.detectBrowser() === BrowserDetection.Browser.OPERA;
     }
 
     static isEdge() {
+        if (!this.isBrowser()) return false;
         return BrowserDetection.detectBrowser() === BrowserDetection.Browser.EDGE;
     }
 
     static isSafari() {
+        if (!this.isBrowser()) return false;
         return BrowserDetection.detectBrowser() === BrowserDetection.Browser.SAFARI;
     }
 
     static isBrave() {
+        if (!this.isBrowser()) return false;
         return BrowserDetection.detectBrowser() === BrowserDetection.Browser.BRAVE;
     }
 
     static isIOS() {
+        if (!this.isBrowser()) return false;
         return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
     }
 
     static isBadIOS() {
+        if (!this.isBrowser()) return false;
         const browserInfo = BrowserDetection.getBrowserInfo();
         // Check for iOS < 11 or 11.2 which has the WASM bug
         return browserInfo.browser === BrowserDetection.Browser.SAFARI
@@ -154,6 +169,7 @@ class BrowserDetection {
      * @returns {Promise}
      */
     static isPrivateMode() {
+        if (!this.isBrowser()) return Promise.resolve(false);
         return new Promise((resolve) => {
             const on = () => resolve(true); // is in private mode
             const off = () => resolve(false); // not private mode

--- a/src/clipboard/Clipboard.ts
+++ b/src/clipboard/Clipboard.ts
@@ -1,5 +1,7 @@
 export class Clipboard {
-    public static copy(text: string) {
+    public static copy(text: string): boolean {
+        if (typeof globalThis.document === 'undefined') return false;
+
         // Simplified and typed version of https://github.com/sindresorhus/copy-text-to-clipboard
         // Additionally added a fix for correctly restoring selections in input fields.
         const element = document.createElement('textarea');

--- a/src/cookie/Cookie.ts
+++ b/src/cookie/Cookie.ts
@@ -4,6 +4,8 @@
  * @returns {string|null} Returns the value of the Cookie, if this one was found. Otherwise return null.
  */
 export function getCookie(cookieName: string): string | null {
+    if (typeof globalThis.document === 'undefined') return null;
+
     const match = document.cookie.match(new RegExp(`(^| )${encodeURIComponent(cookieName)}=([^;]+)`));
     return match && decodeURIComponent(match[2]);
 }
@@ -37,6 +39,8 @@ export function setCookie(
         samesite?: 'lax'|'strict'|'none',
     },
 ) {
+    if (typeof globalThis.document === 'undefined') return;
+
     if (typeof cookieName !== 'string') throw new Error('cookieName must be a string');
     if (typeof cookieValue !== 'string') throw new Error('cookieValue must be a string');
 
@@ -80,5 +84,7 @@ export function setCookie(
  * @param {string} cookieName - the Name / Key of the Cookie to be unset / removed
  */
 export function unsetCookie(cookieName: string) {
+    if (typeof globalThis.document === 'undefined') return;
+
     document.cookie = `${encodeURIComponent(cookieName)}=;max-age=0`;
 }

--- a/src/currency-info/CurrencyInfo.ts
+++ b/src/currency-info/CurrencyInfo.ts
@@ -339,14 +339,16 @@ export class CurrencyInfo {
 
         // Check if we're in a browser environment
         const isBrowserEnv = typeof globalThis.navigator !== 'undefined';
-        const navigatorLanguage = isBrowserEnv ? globalThis.navigator.language : 'en-US';
 
         const nameLocalesToTry = [
             ...(locale ? [locale] : []), // try requested locale
-            ...(isBrowserEnv ? [`${navigatorLanguage.substring(0, 2)}-${currencyCountry}`] : []), // user language as spoken in currency country
-            ...(isBrowserEnv ? [navigatorLanguage] : []), // fallback
-            'en-US', // en-US as last resort
+            ...(isBrowserEnv
+                ? [`${navigator.language.substring(0, 2)}-${currencyCountry}`]
+                : []
+            ), // user language as spoken in currency country
+            ...(isBrowserEnv ? [navigator.language] : []), // fallback
         ];
+
         let supportsDisplayNames = 'DisplayNames' in Intl;
         // also normalizes the locales
         [this.locale] = supportsDisplayNames

--- a/src/currency-info/CurrencyInfo.ts
+++ b/src/currency-info/CurrencyInfo.ts
@@ -337,10 +337,14 @@ export class CurrencyInfo {
         // see https://en.wikipedia.org/wiki/ISO_4217#National_currencies.
         const currencyCountry = this.code.substring(0, 2);
 
+        // Check if we're in a browser environment
+        const isBrowserEnv = typeof globalThis.navigator !== 'undefined';
+        const navigatorLanguage = isBrowserEnv ? globalThis.navigator.language : 'en-US';
+
         const nameLocalesToTry = [
             ...(locale ? [locale] : []), // try requested locale
-            `${navigator.language.substring(0, 2)}-${currencyCountry}`, // user language as spoken in currency country
-            navigator.language, // fallback
+            ...(isBrowserEnv ? [`${navigatorLanguage.substring(0, 2)}-${currencyCountry}`] : []), // user language as spoken in currency country
+            ...(isBrowserEnv ? [navigatorLanguage] : []), // fallback
             'en-US', // en-US as last resort
         ];
         let supportsDisplayNames = 'DisplayNames' in Intl;

--- a/src/request-link-encoding/RequestLinkEncoding.ts
+++ b/src/request-link-encoding/RequestLinkEncoding.ts
@@ -128,7 +128,7 @@ export function createRequestLink(
     recipient: string,
     amountOrOptions?: number | GeneralRequestLinkOptions, // amount in Nim or options object
     message?: string,
-    basePath: string = typeof globalThis.window !== 'undefined' ? globalThis.window.location.host : '',
+    basePath: string = typeof globalThis.window !== 'undefined' ? globalThis.window.location.host : 'wallet.nimiq.com',
 ): string {
     if (typeof amountOrOptions === 'object') {
         switch (amountOrOptions.currency) {
@@ -224,9 +224,13 @@ export function parseRequestLink<C extends Currency>(requestLink: string | URL, 
     return null;
 }
 
+const defaultCreateNimiqRequestLinkOptions: NimiqRequestLinkOptions = {
+    basePath: typeof globalThis.window !== 'undefined' ? globalThis.window.location.host : 'wallet.nimiq.com',
+};
+
 export function createNimiqRequestLink(
     recipient: string,
-    options: NimiqRequestLinkOptions = { basePath: typeof globalThis.window !== 'undefined' ? globalThis.window.location.host : '' },
+    options: NimiqRequestLinkOptions = defaultCreateNimiqRequestLinkOptions,
 ): string {
     const { amount, message, label, basePath, type = NimiqRequestLinkType.SAFE } = options;
 

--- a/src/request-link-encoding/RequestLinkEncoding.ts
+++ b/src/request-link-encoding/RequestLinkEncoding.ts
@@ -128,7 +128,7 @@ export function createRequestLink(
     recipient: string,
     amountOrOptions?: number | GeneralRequestLinkOptions, // amount in Nim or options object
     message?: string,
-    basePath: string = window.location.host,
+    basePath: string = typeof globalThis.window !== 'undefined' ? globalThis.window.location.host : '',
 ): string {
     if (typeof amountOrOptions === 'object') {
         switch (amountOrOptions.currency) {
@@ -226,7 +226,7 @@ export function parseRequestLink<C extends Currency>(requestLink: string | URL, 
 
 export function createNimiqRequestLink(
     recipient: string,
-    options: NimiqRequestLinkOptions = { basePath: window.location.host },
+    options: NimiqRequestLinkOptions = { basePath: typeof globalThis.window !== 'undefined' ? globalThis.window.location.host : '' },
 ): string {
     const { amount, message, label, basePath, type = NimiqRequestLinkType.SAFE } = options;
 


### PR DESCRIPTION
### Summary

Add SSR support to the utils library by guarding browser globals.


### Changes

- Wrap `window`, `document`, `navigator` checks in `typeof globalThis.x !== 'undefined'`
- Provide safe fallbacks in:
   - **RequestLinkEncoding**
   - **BrowserDetection** (`isBrowser`)
   - **Clipboard** (returns `false` on server)
   - **Cookie** (no-op without `document`)
   - **CurrencyInfo**
  
### Approach

Use `globalThis` checks to detect browser APIs at runtime, ensuring the library runs safely in both client and server environments.